### PR TITLE
Fixed compiling the code in Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew install qt --build-bottle --HEAD
 
 ## GNU/Linux
 
-* Install Qt4.8 or Qt5.+ with your distribution package manager (apt, etc...)
+* Install Qt4.8 or Qt5.0+ with your distribution package manager (apt, etc...)
 * Create folder .Hearthstone in your home directory
 * Create symlinks of the Hearthstone's output_log and log.config in the newly created folder
 
@@ -45,12 +45,10 @@ qmake
 make
 ```
 
-(Use ``nmake`` instead of ``make`` on Windows)
-
-On Linux, you might have to do the following if you have qt5 installed
+Alternativelly you can use qt4 to build the application:
 
 ```
-qmake QT+=widgets
+qmake-qt4
 make
 ```
 
@@ -65,7 +63,7 @@ sudo make install
 Default install prefix is /usr/local. You can change it by adding PREFIX argument to qmake-qt4 command eg:
 
 ```
-qmake QT+=widgets PREFIX=/usr
+qmake PREFIX=/usr
 ```
 
 # Contributing

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -68,8 +68,10 @@ int main( int argc, char **argv )
   }
 
   // Logging
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION >= QT_VERSION_CHECK(5,4,0)
   QString dataLocation = QStandardPaths::writableLocation( QStandardPaths::AppDataLocation );
+#elif QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+  QString dataLocation = QStandardPaths::writableLocation( QStandardPaths::DataLocation );
 #else
   QString dataLocation = QDesktopServices::storageLocation( QDesktopServices::DataLocation );
 #endif

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -136,18 +136,10 @@ void Tracker::AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class
 }
 
 QNetworkReply* Tracker::AuthPostJson( const QString& path, const QByteArray& data ) {
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
   QString credentials = "Basic " + ( Username() + ":" + Password() ).toLatin1().toBase64();
-#else
-  QString credentials = "Basic " + ( Username() + ":" + Password() ).toAscii().toBase64();
-#endif
 
   QNetworkRequest request = CreateTrackerRequest( path );
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
   request.setRawHeader( "Authorization", credentials.toLatin1() );
-#else
-  request.setRawHeader( "Authorization", credentials.toAscii() );
-#endif
   request.setHeader( QNetworkRequest::ContentTypeHeader, "application/json" );
   return mNetworkManager.post( request, data );
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,4 +1,4 @@
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#if QT_VERSION >= QT_VERSION_CHECK(5,4,0)
     #include <QtWidgets>
 #else
     #include <QtGui>

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,4 +1,4 @@
-#if QT_VERSION >= QT_VERSION_CHECK(5,4,0)
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     #include <QtWidgets>
 #else
     #include <QtGui>

--- a/track-o-bot.pro
+++ b/track-o-bot.pro
@@ -93,7 +93,7 @@ unix {
         PREFIX = /usr/local
     }
     
-    greaterThan(QT_MAJOR_VERSION, 5) {
+    greaterThan(QT_MAJOR_VERSION, 4) {
         QT += widgets
     } else {
     	QT += gui

--- a/track-o-bot.pro
+++ b/track-o-bot.pro
@@ -92,6 +92,13 @@ unix {
     isEmpty(PREFIX){
         PREFIX = /usr/local
     }
+    
+    greaterThan(QT_MAJOR_VERSION, 5) {
+        QT += widgets
+    } else {
+    	QT += gui
+    }
+    
     desktop.path = $$PREFIX/share/applications
     desktop.files += \
         assets/track-o-bot.desktop


### PR DESCRIPTION
Apparently Ubuntu 14.04 still runs Qt 5.2 instead of Qt 5.4, so some parts of
the code had to be altered to make it be able to be compiled.

Strangely enough, it still doesn't work and I can't find the issue why. The
changes I made should not break anything for other systems, but now
track-o-bot can be compiled using qmake-qt4.

Also some functionality isn't present in Ubuntu. For instance notifications
don't work.