### PR TITLE
Use $DISPLAY value instead of hardcoded :0.0

### DIFF
--- a/src/LinuxWindowCapture.cpp
+++ b/src/LinuxWindowCapture.cpp
@@ -75,7 +75,7 @@ QList<Window> LinuxWindowCapture::listXWindowsRecursive(Display *disp, Window w)
 
 int LinuxWindowCapture::FindWindow( const string& name ) {
     int winId = 0;
-    Display *disp = XOpenDisplay(":0.0");
+    Display *disp = XOpenDisplay(NULL);
     Window rootWin = XDefaultRootWindow(disp);
     QList<Window> windows = listXWindowsRecursive(disp, rootWin);
 


### PR DESCRIPTION
Fixes #13 - according to [xlib docs](https://tronche.com/gui/x/xlib/display/opening.html) this fix uses `$DISPLAY` env variable instead of hardcoded `:0.0`, and with this fix track-o-bot works fine on my system.