### PR TITLE
Fix display name problem when capturing Hearthstone window

### DIFF
--- a/src/LinuxWindowCapture.cpp
+++ b/src/LinuxWindowCapture.cpp
@@ -93,7 +93,7 @@ int LinuxWindowCapture::FindWindow( const string& name ) {
 }
 
 bool LinuxWindowCapture::WindowRect( int windowId, QRect *rect ) {
-    Display *disp = XOpenDisplay(":0.0");
+    Display *disp = XOpenDisplay(NULL);
     QList<Window> windows = listXWindowsRecursive(disp, windowId);
 
     int numWindows = windows.length();


### PR DESCRIPTION
It turns out that this :0.0 thing was hardcoded not in one, but in two places.