### PR TITLE
Fixes double Quit in systray

### DIFF
--- a/src/ui/Window.cpp
+++ b/src/ui/Window.cpp
@@ -146,7 +146,11 @@ void Window::CreateTrayIcon() {
   bool is_kde_plasma = false;
   if(is_linux){
       QString dm = getenv("DESKTOP_SESSION");
-      is_kde_plasma = (dm.toLower() == "plasma");
+      // getenv returns something like /usr/share/xsessions/plasma
+      // so either we match that or we regexp for plasma
+      QRegularExpression plasma_re("plasma$");
+      QRegularExpressionMatch plasma_match = plasma_re.match(dm);
+      is_kde_plasma = plasma_match.hasMatch();
   }
   if(!is_linux || !is_kde_plasma){
     mTrayIconMenu->addSeparator();


### PR DESCRIPTION
This fixes doube quit in systray i had since commit 2fd0328fe831d21704ffe4133681e2b2746dfe7d

Since getenv returns full path ( /usr/share/xsessions/plasma in this case ) we could match this string or use regexp to find plasma. I chose regexp since who knows if there is any other distro that may have different path to xsessions.

I bet there is a better way to handle this since my Qt experience is practically non-existent :)