### PR TITLE
Wine handling v2

### DIFF
--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -17,6 +17,8 @@
 #elif defined Q_OS_LINUX
 #include <math.h>
 #include "LinuxWindowCapture.h"
+#include "WineBottle.h"
+#include "Settings.h"
 #endif
 
 DEFINE_SINGLETON_SCOPE( Hearthstone );
@@ -302,3 +304,17 @@ int Hearthstone::Height() const {
   return mCapture->Height();
 }
 
+QString Hearthstone::DetectWinePrefixPath() const
+{
+  static QString winePrefix;
+
+  if ( winePrefix.isEmpty() ) {
+    // default prefix
+    WineBottle bottle( QDir::homePath() + "/.wine" );
+    if ( bottle.isValid() )
+      winePrefix =  bottle.prefix();
+    else
+      ERR( "Could not determine Wine prefix directory" );
+  }
+  return winePrefix;
+}

--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -56,7 +56,9 @@ void Hearthstone::Update() {
 	bool isRunning = mCapture->WindowFound();
 
 	if( isRunning ) {
-		emit FocusChanged(mCapture->Focus());
+	#ifdef Q_OS_LINUX
+		emit FocusChanged( mCapture->Focus() );
+	#endif
 		static int lastLeft = 0, lastTop = 0, lastWidth = 0, lastHeight = 0;
 		if( lastLeft != mCapture->Left() || lastTop != mCapture->Top() ||
 				lastWidth != mCapture->Width() || lastHeight != mCapture->Height() )

--- a/src/Hearthstone.h
+++ b/src/Hearthstone.h
@@ -44,6 +44,7 @@ public:
 
   QString LogConfigPath() const;
   QString DetectHearthstonePath() const;
+  QString DetectWinePrefixPath() const;
 
   int Width() const;
   int Height() const;
@@ -53,7 +54,7 @@ signals:
   void GameStopped();
   void GameRequiresRestart();
   void GameWindowChanged( int x, int y, int w, int h );
-  void FocusChanged(bool value);
+  void FocusChanged( bool value );
 
 private slots:
   void Update();

--- a/src/LinuxWindowCapture.cpp
+++ b/src/LinuxWindowCapture.cpp
@@ -14,8 +14,11 @@ LinuxWindowCapture::LinuxWindowCapture()
   mTimer = new QTimer( this );
   connect( mTimer, SIGNAL( timeout() ), this, SLOT( Update() ) );
   mTimer->start( LINUX_UPDATE_WINDOW_DATA_INTERVAL );
-
-  Update();
+  /* can't update here cuz we gona end up in infinite loop
+   this file has to be rewritten if we want to use locale based window finding
+   or we cant use  path = Settings::Instance()->HearthstoneDirectoryPath() here
+   */
+  // Update();
 }
 
 void LinuxWindowCapture::Update() {

--- a/src/LinuxWindowCapture.h
+++ b/src/LinuxWindowCapture.h
@@ -22,7 +22,6 @@ private:
   QTimer*  mTimer;
   int      mWinId;
   QRect   mRect;
-  QString ReadAgentAttribute( const char *attributeName ) const;
 
   static int FindWindow( const QString& name );
   static bool WindowRect( int windowId, QRect *rect );

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -17,6 +17,10 @@ DEFINE_SINGLETON_SCOPE( Settings );
 #define KEY_HEARTHSTONE_DIRECTORY_PATH "hearthstoneDirectoryPath"
 #define KEY_OVERLAY_ENABLED "overlayEnabled"
 
+#ifdef Q_OS_LINUX
+#define KEY_WINEPREFIX_PATH "winePrefixPath"
+#endif
+
 Settings::Settings() {
   // Enable overlay by default for new users, but not for existing ones
   if( !QSettings().contains( KEY_OVERLAY_ENABLED ) ) {
@@ -121,4 +125,21 @@ void Settings::SetHearthstoneDirectoryPath( const QString& path ) {
   s.setValue( KEY_HEARTHSTONE_DIRECTORY_PATH, path );
 
   emit HearthstoneDirectoryPathChanged( path );
+}
+
+QString Settings::WinePrefixPath()
+{
+	QString path = QSettings().value( KEY_WINEPREFIX_PATH ).toString();
+	if ( path.isEmpty() ) {
+		path = Hearthstone::Instance()->DetectWinePrefixPath();
+	}
+	return path;
+}
+
+void Settings::SetWinePrefixPath( const QString& path )
+{
+  QSettings s;
+  s.setValue( KEY_WINEPREFIX_PATH, path );
+
+  emit WinePrefixPathChanged( path );
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -6,7 +6,7 @@ class Settings : public QObject
 {
   Q_OBJECT
 
-  DEFINE_SINGLETON( Settings )
+  DEFINE_SINGLETON( Settings );
 
 signals:
   void AccountChanged( const QString& username, const QString& password );

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -16,6 +16,7 @@ signals:
   void DebugEnabledChanged( bool enabled );
   void HearthstoneDirectoryPathChanged( const QString& path );
   void OverlayEnabledChanged( bool enabled );
+  void WinePrefixPathChanged( const QString& path );
 
 public:
   QString AccountUsername() const;
@@ -41,4 +42,7 @@ public:
 
   QString HearthstoneDirectoryPath() const;
   void SetHearthstoneDirectoryPath( const QString& path );
+
+  QString WinePrefixPath();
+  void SetWinePrefixPath( const QString& path );
 };

--- a/src/WineBottle.cpp
+++ b/src/WineBottle.cpp
@@ -1,0 +1,197 @@
+#include "WineBottle.h"
+#include <QDebug>
+
+#define SYSTEM_REG "system.reg"
+#define USER_REG "user.reg"
+#define USERDEF_REG "userdef.reg"
+#define DOSDEVICES "dosdevices"
+#define DRIVE_C "drive_c"
+
+WineBottle::WineBottle( const QString& prefix )
+	: mWinePrefix( prefix ),
+		mSystemReg( nullptr ),
+		mUserReg( nullptr ),
+		mUserdefReg( nullptr ),
+		mRegFormat( QSettings::registerFormat( "reg", ReadWineRegFile, nullptr ) ) {
+	SetupDosDevices();
+}
+
+WineBottle::~WineBottle() {
+	if ( mSystemReg )
+		delete mSystemReg;
+	if ( mUserReg )
+		delete mUserReg;
+	if ( mUserdefReg )
+		delete mUserdefReg;
+}
+
+const QString& WineBottle::Path() {
+	return mWinePrefix;
+}
+
+QString WineBottle::DosDevicePath(const QChar& drive) {
+	return mDosDevices[ drive.toLower() ];
+}
+
+bool WineBottle::IsValid() {
+	QStringList matchList;
+	matchList << DOSDEVICES << DRIVE_C
+						<< SYSTEM_REG << USER_REG << USERDEF_REG;
+
+	int count = 0;
+	foreach( const QFileInfo& info, QDir( mWinePrefix ).entryInfoList()  ) {
+		if ( matchList.contains( info.fileName() ) )
+				 ++count;
+	}
+
+	if ( count == matchList.size() )
+		return true;
+
+	return false;
+}
+
+QVariant WineBottle::ReadRegistryValue( const QString& key ) {
+
+	if ( mSystemReg == nullptr )
+		mSystemReg = new QSettings( mWinePrefix + "/" + SYSTEM_REG , mRegFormat );
+	if ( mUserReg == nullptr )
+		mUserReg = new QSettings( mWinePrefix + "/" + USER_REG , mRegFormat );
+	if ( mUserdefReg == nullptr )
+		mUserdefReg = new QSettings( mWinePrefix + "/" + USERDEF_REG, mRegFormat );
+
+	if ( mSystemReg->value( key ).isValid() )
+		return mSystemReg->value( key );
+	else if ( mUserReg->value( key ).isValid() )
+		return mUserReg->value( key );
+	else if ( mUserdefReg->value( key ).isValid() )
+		return mUserdefReg->value( key );
+	else
+		return QVariant();
+}
+
+QString WineBottle::ToSystemPath(const QString& windowsStylePath ) {
+
+	QString path = windowsStylePath;
+	QString drivePath = DosDevicePath( windowsStylePath.at( 0 ) );
+
+	path.replace( "\\\\", QDir::separator() );
+	path[ 0 ].toLower();
+
+	if ( !drivePath.endsWith( QDir::separator() ) )
+		drivePath.append( QDir::separator() );
+
+	return path.replace( 0, 3, drivePath );
+}
+
+// gather all "drives" for this wine prefix
+void WineBottle::SetupDosDevices() {
+	QDir prefix( mWinePrefix );
+	if ( prefix.cd( DOSDEVICES ) ) {
+		/**
+		 *  dosdevices dir should contain (directories) symlinks to "drives"
+		 *  i.e. 'c:', 'd:'....
+		 **/
+		foreach ( const QFileInfo& dosdevice, prefix.entryInfoList( QDir::Dirs | QDir::NoDotAndDotDot	 ) ) {
+			if ( ( dosdevice.baseName().size() == 2 ) &&
+					 ( dosdevice.baseName().at(0).isLetter() ) &&
+					 ( dosdevice.baseName().at(1) == ':' ) ) {
+				mDosDevices.insert( dosdevice.baseName().at(0), dosdevice.symLinkTarget() );
+			}
+		}
+	}
+}
+
+// lets blame this on my poor programming skills
+bool WineBottle::ReadWineRegFile(QIODevice& device, QSettings::SettingsMap& map) {
+
+	if ( !device.isOpen() )
+		return false;
+
+	device.setTextModeEnabled( true );
+	QTextStream inputStream( &device );
+
+	// first line should be: WINE REGISTRY Version 2
+	if ( inputStream.readLine() != "WINE REGISTRY Version 2" ) {
+		return false;
+	}
+	// determine what prefix needs to be prepend
+
+	QString line = inputStream.readLine();
+	QString defaultPrefix, prefix;
+
+	if ( line == ";; All keys relative to \\\\Machine" ) {
+		// system.reg
+		// ;; All keys relative to \\Machine
+		defaultPrefix = "HKEY_LOCAL_MACHINE/";
+	}
+	else if ( line == ";; All keys relative to \\\\User\\\\.Default") {
+		// userdef.reg
+		defaultPrefix = "HKEY_USERS/.Default/";
+	}
+	else if ( line.left( 32 ) == ";; All keys relative to \\\\User\\\\") {
+		// has to be user.reg since we cought userdef earlier
+		// ;; All keys relative to \\User\\x-x-x-x-x-x-x-xxxx
+		// resides in two places:
+		// HKEY_CURRENT_USER/ and HKEY_USERS/User/x-x-x-x-x-x-x-xxxx
+		// howerever we need only current user one
+		defaultPrefix = "HKEY_CURRENT_USER/";
+	}
+	else {
+		qDebug() << "Error: Could not determine prefix!";
+		return false;
+	}
+
+	// now we fill SettingsMap
+	QString key, valueString;
+	QStringList explode;
+	QVariant value;
+
+	while ( !inputStream.atEnd() ) {
+		line = inputStream.readLine();
+
+		if ( line.startsWith( '#' ) ) {} 				/* skip comment */
+		/* empty line means that next section is starting so prefix has to be cleared */
+		else if ( line.startsWith( '\n' ) ) {
+			prefix.clear();
+		}
+		else if ( line.startsWith( '[' ) ) { 		/* found new section */
+			prefix = ( line.mid( 1, line.indexOf( "]" ) - 1 ) ).
+							 replace( "\\\\", QDir::separator() );
+			prefix.prepend( defaultPrefix );
+		}
+		/* found key */
+		//else if ( line.startsWith( '\' ) || line.startsWith( '@' ) )
+		else if ( line.startsWith( '"' ) ) {
+			explode = line.split( '=' );
+
+			key =  explode[ 0 ].replace( "\"" , "" );
+			// cannot replace " cuz we dont know the type
+			valueString = explode[ 1 ];
+
+			// REG_SZ
+			if ( valueString.startsWith( '"' ) && valueString.endsWith( '"' )) {
+				value.setValue( valueString.mid( 1, valueString.length() - 2 ));
+			}
+			// REG_DWORD
+			else if ( valueString.startsWith( "dword:" )) {
+				unsigned long dword = valueString.mid( 6 ).toULong();
+				value.setValue( dword );
+			}
+			// REG_BINARY do i even need this?
+			// TODO: finish this someday
+//			else if ( valueString.startsWith( "hex:")) {
+//			}
+//			// REG_MULTI_SZ */
+//			else if ( valueString.startsWith( "str(" ) ) {
+//			}
+//
+			/* insert key and value to map */
+			map [ prefix + "/" + key ] = value;
+			key.clear();
+			value.clear();
+		} else {
+			// unhandeled stuff we dont need
+		}
+	}
+	return true;
+}

--- a/src/WineBottle.h
+++ b/src/WineBottle.h
@@ -47,6 +47,7 @@ public:
    * @return value for a given key or QVariant(invalid) if none is found/error
    */
   QVariant ReadRegistryValue( const QString& key );
+private:
   /**
    * @brief Scans prefix to set up m_dosDevices
    */

--- a/src/WineBottle.h
+++ b/src/WineBottle.h
@@ -1,0 +1,77 @@
+#ifndef WINEBOTTLE_H
+#define WINEBOTTLE_H
+
+#include <QString>
+#include <QSettings>
+#include <QDir>
+#include <QList>
+#include <QMap>
+
+class WineBottle {
+public:
+  /**
+   * @brief Wine prefix
+   * @param prefix is a path to the directory containing wine's prefix
+   */
+  WineBottle( const QString& Path );
+  /**
+   * @brief destructor
+   */
+  ~WineBottle();
+  /**
+   * @brief Returns path to Wine prefix
+   * @retun wine prefix
+   */
+  const QString& Path();
+  /**
+   * @brief Translates windows style path to system's path
+   *
+   * For examlple:
+   *    assuming we have 2 dosdevices, c: and d:
+   * 		c: -> {$wineprefix}/drive_c
+   *    d: -> /
+   *
+   *    and the path is d:\\mnt\\drive\Hearthstone
+   *    then we get /mnt/drive/Hearthstone
+   * @param windows style path
+   */
+  QString ToSystemPath( const QString& windowsStylePath );
+  /**
+   * @brief is WineBottle a valid wine prefix
+   * @return true if yes, false if no
+   */
+  bool IsValid();
+  /**
+   * @brief Reads values stored in wine's registry
+   * @param key
+   * @return value for a given key or QVariant(invalid) if none is found/error
+   */
+  QVariant ReadRegistryValue( const QString& key );
+  /**
+   * @brief Scans prefix to set up m_dosDevices
+   */
+  void SetupDosDevices();
+  /**
+   * @brief Custom format readder ( *.reg ) for QSettings
+   */
+  static bool ReadWineRegFile( QIODevice& device, QSettings::SettingsMap& map );
+  /**
+   * @brief Returns absolute path to the Wine's "drive"
+   *
+   * "Drives" are stored in {$wineprefix}/dosdevices/ as symlinks
+   * to directories
+   *
+   * @param drive
+   * @return absolute path to the drive
+   */
+  QString DosDevicePath( const QChar& drive );
+
+	QString mWinePrefix;                /**< path to the prefix */
+	QMap< QChar, QString > mDosDevices; /**< "dosDrives" mapped to their symlinked locations */
+	QSettings* mSystemReg;              /**< HKEY_LOCAL_MACHINE keys */
+	QSettings* mUserReg;                /**<  HKEY_USERS/.Default keys */
+	QSettings* mUserdefReg;             /**< HKEY_CURRENT_USER keys */
+	const QSettings::Format mRegFormat; /**< custom registry format */
+};
+
+#endif // WINEBOTTLE_H

--- a/src/ui/SettingsTab.cpp
+++ b/src/ui/SettingsTab.cpp
@@ -76,3 +76,21 @@ void SettingsTab::SelectHearthstoneDirectoryPath() {
     msgBox.exec();
   }
 }
+
+void SettingsTab::SelectWinePrefixPath()
+{
+  QString currentPath = Settings::Instance()->HearthstoneDirectoryPath();
+
+  QString dir = QFileDialog::getExistingDirectory( this, tr("Select wine prefix directory"),
+     currentPath, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks );
+
+  if( !dir.isEmpty() ) {
+    Settings::Instance()->SetWinePrefixPath( dir );
+    LoadSettings();
+
+    QMessageBox msgBox( QMessageBox::Information,
+        "Restart required!",
+        "Please restart Track-o-Bot for changes to take effect!", QMessageBox::Ok, this );
+    msgBox.exec();
+  }
+}

--- a/src/ui/SettingsTab.cpp
+++ b/src/ui/SettingsTab.cpp
@@ -17,6 +17,7 @@ SettingsTab::SettingsTab( QWidget *parent )
   connect( mUI->checkOverlay, &QAbstractButton::clicked, this, &SettingsTab::UpdateOverlayEnabled );
   connect( mUI->selectHearthstoneDirectoryPath, &QAbstractButton::clicked, this, &SettingsTab::SelectHearthstoneDirectoryPath );
 #if defined Q_OS_LINUX
+  connect( mUI->selectWinePrefixDirectoryPath, &QAbstractButton::clicked, this, &SettingsTab::SelectWinePrefixPath );
   mUI->checkForUpdatesNowButton->hide();
   mUI->checkForUpdates->setDisabled(true);
 #else
@@ -58,6 +59,9 @@ void SettingsTab::LoadSettings() {
   mUI->checkDebug->setChecked( settings->DebugEnabled() );
   mUI->checkOverlay->setChecked( settings->OverlayEnabled() );
   mUI->hearthstoneDirectoryPath->setText( settings->HearthstoneDirectoryPath() );
+#ifdef Q_OS_LINUX
+  mUI->winePrefixDirectoryPath->setText( settings->WinePrefixPath() );
+#endif
 }
 
 void SettingsTab::SelectHearthstoneDirectoryPath() {

--- a/src/ui/SettingsTab.h
+++ b/src/ui/SettingsTab.h
@@ -25,5 +25,6 @@ public slots:
   void UpdateOverlayEnabled();
   void SelectHearthstoneDirectoryPath();
   void LoadSettings();
+  void SelectWinePrefixPath();
 };
 

--- a/src/ui/SettingsWidget.ui
+++ b/src/ui/SettingsWidget.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>337</height>
+    <width>500</width>
+    <height>468</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>290</height>
+    <height>390</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,8 @@
 QLabel#debugDescription,
 QLabel#hearthstonePathDescription,
 QLabel#overlayDescription,
-QLabel#updateDescription {
+QLabel#updateDescription ,
+QLabel#winePrefixPathDescription{
 	font-size: 11px;
 	color: #898989;
 }</string>
@@ -51,6 +52,86 @@ QLabel#updateDescription {
       <number>0</number>
      </property>
      <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Wine</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="5,1">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="winePrefixDirectoryPath">
+           <property name="text">
+            <string>Select path...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="winePrefixPathDescription">
+           <property name="text">
+            <string>This should point to the Wine prefix directory.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="QPushButton" name="selectWinePrefixDirectoryPath">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="1">
+      <spacer name="verticalSpacer_9">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Game</string>
@@ -60,7 +141,7 @@ QLabel#updateDescription {
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="2" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="5,1">
        <property name="spacing">
         <number>0</number>
@@ -110,34 +191,44 @@ QLabel#updateDescription {
            </property>
           </widget>
          </item>
-         <item>
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::MinimumExpanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
         </layout>
        </item>
       </layout>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
+      <spacer name="verticalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>5</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="4" column="1">
       <widget class="QCheckBox" name="checkOverlay">
        <property name="text">
         <string>Enable in-game overlay</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
+      <widget class="QLabel" name="overlayDescription">
+       <property name="text">
+        <string>Hover over your or your opponent's deck to see which cards were drawn or played.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
       <spacer name="verticalSpacer_3">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -153,28 +244,28 @@ QLabel#updateDescription {
        </property>
       </spacer>
      </item>
-     <item row="5" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>System</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="7" column="1">
       <widget class="QCheckBox" name="startAtLogin">
        <property name="text">
         <string>Start at login </string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="8" column="1">
       <widget class="QLabel" name="startDescription">
        <property name="text">
         <string>Open Track-o-Bot when you log in.</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -185,26 +276,26 @@ QLabel#updateDescription {
        <property name="sizeHint" stdset="0">
         <size>
          <width>20</width>
-         <height>5</height>
+         <height>13</height>
         </size>
        </property>
       </spacer>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QCheckBox" name="checkForUpdates">
        <property name="text">
         <string>Check for updates</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QLabel" name="updateDescription">
        <property name="text">
         <string>Check for updates automatically.</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="12" column="1">
       <widget class="QPushButton" name="checkForUpdatesNowButton">
        <property name="enabled">
         <bool>true</bool>
@@ -229,7 +320,7 @@ QLabel#updateDescription {
        </property>
       </widget>
      </item>
-     <item row="12" column="1">
+     <item row="13" column="1">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -245,21 +336,21 @@ QLabel#updateDescription {
        </property>
       </spacer>
      </item>
-     <item row="13" column="0">
+     <item row="14" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Debug</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
+     <item row="14" column="1">
       <widget class="QCheckBox" name="checkDebug">
        <property name="text">
         <string>Enable debug mode</string>
        </property>
       </widget>
      </item>
-     <item row="14" column="1">
+     <item row="15" column="1">
       <widget class="QLabel" name="debugDescription">
        <property name="text">
         <string>Debug mode increases verbosity of output in the log tab and sends diagnostic data.</string>
@@ -269,33 +360,7 @@ QLabel#updateDescription {
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="overlayDescription">
-       <property name="text">
-        <string>Hover over your or your opponent's deck to see which cards were drawn or played.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <spacer name="verticalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>5</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="15" column="1">
+     <item row="16" column="1">
       <spacer name="verticalSpacer_6">
        <property name="orientation">
         <enum>Qt::Vertical</enum>

--- a/track-o-bot.pro
+++ b/track-o-bot.pro
@@ -120,8 +120,10 @@ win32 {
 
 unix {
     DEFINES += PLATFORM=\\\"linux\\\"
-    HEADERS += src/LinuxWindowCapture.h
-    SOURCES += src/LinuxWindowCapture.cpp
+    HEADERS += src/LinuxWindowCapture.h \
+               src/WineBottle.h
+    SOURCES += src/LinuxWindowCapture.cpp \
+               src/WineBottle.cpp
     RESOURCES = linux.qrc
     LIBS +=  -lGL -lGLU -lXext -lX11 -lXfixes -L/usr/lib/x86_64-linux-gnu/
     CONFIG += link_pkgconfig debug


### PR DESCRIPTION
Hey.
This code attempts to get rid of the need to symlink things to ~/.Heartstone 
directory when new features are added ( one has to follow what project does in 
order make those symlinks ). Now you can select wine prefix and hs directory and 
it should be now possible to automagically* detect log.config and other things 
like cards db.

For a new user with fresh ( default ) prefix and default hs path ToB should 
detect things automatically without any need for configuration (assuming no config file present).

If you want to test it backup your config :)