### PR TITLE
LinuxCaptureWindow rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
+sudo: required
+dist: trusty
+
 before_install:
 #add required repositories
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-add-repository -y ppa:beineri/opt-qt551
- - sudo apt-get update -qq
- - sudo apt-get install qt55base qt55tools qt55svg qt55webkit qt55script
+ - sudo apt-add-repository -y ppa:beineri/opt-qt551-trusty
+ - sudo apt-get update -qq -y
+ - sudo apt-get install qt55base qt55tools qt55svg qt55webkit qt55script -y
+ - sudo apt-get install libxcb1-dev libxcb-icccm4-dev -y
 
 language: cpp
 
 script:
  - /opt/qt55/bin/qmake && make && make test
- 

--- a/README.md
+++ b/README.md
@@ -11,21 +11,32 @@ brew install qt5
 brew link qt5 --force
 ```
 
-* Install [Sparkle](http://sparkle.andymatuschak.org/) 
+* Install [Sparkle](http://sparkle.andymatuschak.org/)
  * Move _Sparkle.framework_ to ``/Library/Frameworks``.
 
 ## Windows
 
-* Install [Qt](http://qt-project.org/downloads) 
+* Install [Qt](http://qt-project.org/downloads)
  * I use the Qt libraries 5.5.0 for Windows VS 2012.
-* Install [WinSparkle](https://github.com/vslavik/winsparkle) 
+* Install [WinSparkle](https://github.com/vslavik/winsparkle)
  * Clone the repository and build the library, for example with VS 2012. The precompiled releases are ancient.
 
 ## GNU/Linux
 
 * Install Qt5.5+ with your distribution package manager (apt, etc...)
-* Create folder .Hearthstone in your home directory
-* Track-o-Bot now relies on Power.log, Zone.log, Asset.log and Bod.log, you just have to select your Wine prefix and the Hearthstone's install directory in the ToB configuration window
+
+You also need development packages for:
+
+* qt5-base
+* mesa
+* xcb
+* xcb-icccm
+
+on Ubuntu this should install all required development packages:
+
+```
+sudo apt-get install build-essential qt5-default qtbase5-dev libxcb1-dev libxcb-icccm4-dev
+```
 
 # Build Instructions
 
@@ -50,7 +61,7 @@ qmake PREFIX=/usr
 
 # Contributing
 
-Feel free to submit pull requests, suggest new ideas and discuss issues. Track-o-Bot is about simplicity and usability. Only features which benefit all users will be considered. 
+Feel free to submit pull requests, suggest new ideas and discuss issues. Track-o-Bot is about simplicity and usability. Only features which benefit all users will be considered.
 
 # License
 

--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -42,7 +42,11 @@ Hearthstone::Hearthstone()
   // So just check only once in a while
   mTimer = new QTimer( this );
   connect( mTimer, &QTimer::timeout, this, &Hearthstone::Update );
-#ifdef Q_OS_MAC
+#ifdef Q_OS_LINUX
+  connect( this, &Hearthstone::GameStarted, this, &Hearthstone::SetFastUpdates );
+  connect( this, &Hearthstone::GameStopped, this, &Hearthstone::SetSlowUpdates );
+  mTimer->start( 5000 );
+#elif defined Q_OS_MAC
   mTimer->start( 5000 );
 #else
   mTimer->start( 250 );
@@ -273,7 +277,7 @@ QString Hearthstone::DetectHearthstonePath() const {
 			WineBottle bottle( winePrefix );
 			// path is windows style ie c:\\\Program Files\\..
 			QString path =
-                bottle.ReadRegistryValue( "HKEY_LOCAL_MACHINE/Software/Microsoft/Windows/CurrentVersion/Uninstall/Hearthstone/InstallLocation" ).toString();
+								bottle.ReadRegistryValue( "HKEY_LOCAL_MACHINE/Software/Microsoft/Windows/CurrentVersion/Uninstall/Hearthstone/InstallLocation" ).toString();
 
 			if ( !path.isEmpty() ) {
 				// need to translate path to *nix style path

--- a/src/Hearthstone.h
+++ b/src/Hearthstone.h
@@ -58,4 +58,8 @@ signals:
 
 private slots:
   void Update();
+#ifdef Q_OS_LINUX
+  void SetSlowUpdates() { mTimer->setInterval( 5000 ); }
+  void SetFastUpdates() { mTimer->setInterval( 250 ); }
+#endif
 };

--- a/src/LinuxWindowCapture.cpp
+++ b/src/LinuxWindowCapture.cpp
@@ -43,11 +43,7 @@ int LinuxWindowCapture::Top() {
 QPixmap LinuxWindowCapture::Capture( int x, int y, int w, int h ) {
     LOG("Capturing window: %d, %d, %d, %d", x, y, h, w );
     QScreen *screen = QGuiApplication::primaryScreen();
-    QPixmap pixmap = screen->grabWindow( mWindow,
-                                         x + mRect.x(),
-                                         y + mRect.y(),
-                                         w,
-                                         h );
+    QPixmap pixmap = screen->grabWindow( mWindow, x, y, w, h );
   return pixmap;
 }
 

--- a/src/LinuxWindowCapture.h
+++ b/src/LinuxWindowCapture.h
@@ -1,39 +1,23 @@
-#pragma once
+#ifndef LINUXWINDOWCAPTURE_H
+#define LINUXWINDOWCAPTURE_H
 
 #include "WindowCapture.h"
-
-#include <QTimer>
-#include <QGuiApplication>
-#include <QScreen>
-#include <QFile>
-#include <QDesktopServices>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <X11/Xlib.h>
-
-// FindWindow is quite intensive in terms of performance
-#define LINUX_UPDATE_WINDOW_DATA_INTERVAL 3000 // ms
+#include <xcb/xcb.h>
 
 class LinuxWindowCapture : public QObject, public WindowCapture
 {
 Q_OBJECT
 
 private:
-  QTimer*  mTimer;
-  int      mWinId;
+  xcb_window_t mWindow;
   QRect   mRect;
 
-  static int FindWindow( const QString& name );
-  static bool WindowRect( int windowId, QRect *rect );
-
-  bool Fullscreen();
-
-private slots:
-  void Update();
+  xcb_window_t FindWindow( const QString& wmName, const QString& wmClass );
+  QList< xcb_window_t > listWindowsRecursive( xcb_connection_t* dpy, xcb_window_t& window );
+  bool WindowRect();
 
 public:
   LinuxWindowCapture();
-  static QList<Window> listXWindowsRecursive(Display *disp, Window w);
 
   bool WindowFound();
   int Width();
@@ -46,3 +30,4 @@ public:
   bool Focus();
 };
 
+#endif // LINUXWINDOWCAPTURE_H

--- a/track-o-bot.pro
+++ b/track-o-bot.pro
@@ -126,7 +126,7 @@ unix {
     SOURCES += src/LinuxWindowCapture.cpp \
                src/WineBottle.cpp
     RESOURCES = linux.qrc
-    LIBS +=  -lGL -lGLU -lXext -lX11 -lXfixes -L/usr/lib/x86_64-linux-gnu/
+    LIBS +=  -lGL -lGLU -lxcb -lxcb-icccm -L/usr/lib/x86_64-linux-gnu/
     CONFIG += link_pkgconfig debug
     PKGCONFIG += x11
     CODECFORSRC = UTF-8


### PR DESCRIPTION
Hey, i wanted to clean up things in linuxwindowcapture and i ended up rewriting the whole thing. Now it's based on xcb rather then xlib and requires window manager supporting icccm standard ( which according to this: https://en.wikipedia.org/wiki/Comparison_of_X_window_managers means that all except some obscure wm will support it ). A nice bonus of a rewrite is a small performance boost ( on my system searching for a window on release build takes ~4ms vs average ~7ms with the old code when HS isnt running ). 

I've also added change of update interval based on HS state ( started/stopped ) which i'll try to send upstream.

Good luck testing and reviewing :)

PS rank detection didnt work for me before this and it doesnt work now. Im trying to figure out whats going on.