### PR TITLE
Linux: Remove mask from overlay

### DIFF
--- a/src/ui/Overlay.cpp
+++ b/src/ui/Overlay.cpp
@@ -283,16 +283,6 @@ void Overlay::HandleGameWindowChanged( int x, int y, int w, int h ) {
   mPlayerDeckRect = QRect( w / 2 + 0.440 * minWidth, h * 0.510, 0.05 * minWidth, h * 0.170 );
   mOpponentDeckRect = mPlayerDeckRect.translated( -0.005 * minWidth, -0.275 * h );
 
-#ifdef Q_OS_LINUX
-  int maskWidth = w - mPlayerDeckRect.x();
-  if(maskWidth < 200){
-      maskWidth = 200;
-  }
-  QRect maskRect = QRect(mPlayerDeckRect.x(), 0, w - mPlayerDeckRect.x(), h - 100);
-  QRegion region = QRegion(maskRect, QRegion::Rectangle);
-  setMask(region);
-#endif
-
   Update();
 }
 


### PR DESCRIPTION
Depending on screen size the mask being set doesn't gel with where the paint code tries to paint, resulting in a clipped overlay.  Also, the minimum width of 200 is computed but never used.

However, I can't currently see what it's useful for.  Why clip it at all rather than just not paint where you don't want to paint?  Does qt not deal with this well?

It was introduced in https://github.com/BOSSoNe0013/track-o-bot/commit/9b4222a457154babd4878855787021990ba50c3f, but there isn't any specific reasoning given so the original logic may no longer apply?

Removing it fixes the overlay on my 1600x1200 window, which was previously clipped. 