### PR TITLE
Simplify LinuxWindowCapture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
  - sudo apt-add-repository -y ppa:beineri/opt-qt551-trusty
  - sudo apt-get update -qq -y
- - sudo apt-get install qt55base qt55tools qt55svg qt55webkit qt55script -y
+ - sudo apt-get install qt55base qt55tools qt55svg qt55webkit qt55script qt55x11extras -y
  - sudo apt-get install libxcb1-dev libxcb-icccm4-dev -y
 
 language: cpp

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 You also need development packages for:
 
 * qt5-base
+* qt5-x11extras
 * mesa
 * xcb
 * xcb-icccm
@@ -15,7 +16,7 @@ You also need development packages for:
 on Ubuntu this should install all required development packages:
 
 ```
-sudo apt-get install build-essential qt5-default qtbase5-dev libxcb1-dev libxcb-icccm4-dev
+sudo apt-get install build-essential qt5-default qtbase5-dev libqt5x11extras5-dev libxcb1-dev libxcb-icccm4-dev
 ```
 
 ## Build Instructions

--- a/src/LinuxWindowCapture.h
+++ b/src/LinuxWindowCapture.h
@@ -13,7 +13,7 @@ private:
   QRect   mRect;
 
   xcb_window_t FindWindow( const QString& wmName, const QString& wmClass );
-  QList< xcb_window_t > listWindowsRecursive( xcb_connection_t* dpy, xcb_window_t& window );
+  QList< xcb_window_t > listWindowsRecursive( const xcb_window_t& window );
   bool WindowRect();
 
 public:

--- a/src/ui/Overlay.cpp
+++ b/src/ui/Overlay.cpp
@@ -15,11 +15,6 @@
 #include <QJsonDocument>
 #include <QFile>
 #include <QMouseEvent>
-#include "../LinuxWindowCapture.h"
-#include <X11/Xlib.h>
-
-#include <X11/extensions/Xfixes.h>
-#include <X11/extensions/shape.h>
 
 #define CHECK_FOR_OVERLAY_HOVER_INTERVAL_MS 100
 

--- a/track-o-bot.pro
+++ b/track-o-bot.pro
@@ -126,9 +126,9 @@ unix {
     SOURCES += src/LinuxWindowCapture.cpp \
                src/WineBottle.cpp
     RESOURCES = linux.qrc
-    LIBS +=  -lGL -lGLU -lxcb -lxcb-icccm -L/usr/lib/x86_64-linux-gnu/
+    #LIBS +=  -lGL -lGLU -lxcb -lxcb-icccm -L/usr/lib/x86_64-linux-gnu/
     CONFIG += link_pkgconfig debug
-    PKGCONFIG += x11
+    PKGCONFIG += xcb xcb-icccm
     CODECFORSRC = UTF-8
     isEmpty(PREFIX){
         PREFIX = /usr/local
@@ -139,6 +139,7 @@ unix {
     } else {
         QT += gui
     }
+    QT += x11extras
 
     desktop.path = $$PREFIX/share/applications
     desktop.files += \


### PR DESCRIPTION
-Use QX11Info class to obtain xcb connection ( this adds QX11Extras as
dependency )
-Remove redundant headers.
-Update travis config to reflect changes.
-Update README to reflect changes.
-Use pkgconfig to obtain pkg info instead of hardcoded library locations