### PR TITLE
FindWindow: WM_CLASS compare case insensitive

### DIFF
--- a/src/LinuxWindowCapture.cpp
+++ b/src/LinuxWindowCapture.cpp
@@ -110,8 +110,8 @@ xcb_window_t LinuxWindowCapture::FindWindow( const QString& instanceName, const 
     xcb_get_property_cookie_t wmClassC = xcb_icccm_get_wm_class( xcbConn, win );
 
     if ( xcb_icccm_get_wm_class_reply( xcbConn, wmClassC, &wmNameR, nullptr ) ) {
-      if( !qstrcmp( wmNameR.class_name, qt2cstr( windowClass ) ) ||
-          !qstrcmp( wmNameR.instance_name, qt2cstr ( instanceName ) ) ) {
+      if( !qstricmp( wmNameR.class_name, qt2cstr( windowClass ) ) ||
+          !qstricmp( wmNameR.instance_name, qt2cstr ( instanceName ) ) ) {
         winID = win;
         break;
       }


### PR DESCRIPTION
Hi, i had to change the comparison to case insensitive because my VM_CLASS was "hearthstone.exe" like shown below:

xprop | grep -i class
WM_CLASS(STRING) = "hearthstone.exe", "Wine"

The case insensitive check on the instance_name it's not necessary, but who knows...

Please let me know.
Thanks for your time.
Best regards.
Karl